### PR TITLE
Fix: The configuration file is generated in the current directory and improve the use of containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ upx
 *.swp
 *.swn
 upx-*
+/.idea
+/.vscode
+.upx.cfg

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ $ go get github.com/polym/upx
 ### Docker
 
 ```bash
-docker build -t upx .
-docker run --rm upx upx -v
+$ docker build -t upx .
+$ docker run --rm upx upx -v
+$ docker run --rm --volume YOUR_PATH:/go/src/upx upx upx login {Bucket} {Operator} {Password}
+$ docker run --rm --volume YOUR_PATH:/go/src/upx upx upx info
 ```
 
 ## 使用

--- a/config.go
+++ b/config.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
-	"runtime"
+	"strings"
 )
 
 const (
@@ -156,10 +157,15 @@ func saveConfigToFile() {
 }
 
 func getConfigName() string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(os.Getenv("USERPROFILE"), ".upx.cfg")
+	return filepath.Join(getCurrentDirectory(), ".upx.cfg")
+}
+
+func getCurrentDirectory() string {
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		log.Fatal(err)
 	}
-	return filepath.Join(os.Getenv("HOME"), ".upx.cfg")
+	return strings.Replace(dir, "\\", "/", -1)
 }
 
 func hashEncode(s string) string {


### PR DESCRIPTION
由于该容器无法以守护状态运行，所以提此PR.

The configuration file is generated in the current directory and improve the use of containers

change:
1. 配置文件在当前目录下生成
2. 使用容器的时候，带上 `volume` 映射，更加方便

以上在 `Windows 10` 环境和 `Manjaro Linux` 环境进行**编译测试**和**容器测试**，均无问题

```bash
$ docker build -t upx .
$ docker run --rm upx upx -v
$ docker run --rm --volume YOUR_PATH:/go/src/upx upx upx login {Bucket} {Operator} {Password}
$ docker run --rm --volume YOUR_PATH:/go/src/upx upx upx info
```