### PR TITLE
bugfix progress

### DIFF
--- a/io.go
+++ b/io.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/gosuri/uiprogress"
 )
 
 var (
@@ -16,11 +18,15 @@ var (
 type WrappedWriter struct {
 	w      io.WriteCloser
 	Copyed int
+	bar    *uiprogress.Bar
 }
 
 func (w *WrappedWriter) Write(b []byte) (int, error) {
 	n, err := w.w.Write(b)
 	w.Copyed += n
+	if w.bar != nil {
+		w.bar.Set(w.Copyed)
+	}
 	return n, err
 }
 
@@ -28,7 +34,7 @@ func (w *WrappedWriter) Close() error {
 	return w.w.Close()
 }
 
-func NewFileWrappedWriter(localPath string) (*WrappedWriter, error) {
+func NewFileWrappedWriter(localPath string, bar *uiprogress.Bar) (*WrappedWriter, error) {
 	fd, err := os.Create(localPath)
 	if err != nil {
 		return nil, err
@@ -37,6 +43,7 @@ func NewFileWrappedWriter(localPath string) (*WrappedWriter, error) {
 	return &WrappedWriter{
 		w:      fd,
 		Copyed: 0,
+		bar:    bar,
 	}, nil
 }
 


### PR DESCRIPTION
fix panic when total = 0
```
panic: runtime error: index out of range [0] with length 0

goroutine 6 [running]:
github.com/gosuri/uiprogress.(*Bar).Bytes(0xc0002acc00, 0xc00007c1e0, 0xc00030ed20, 0xc000284f78)
        /disk/ssd1/go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/bar.go:195 +0x525
github.com/gosuri/uiprogress.(*Bar).String(...)
        /disk/ssd1/go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/bar.go:214
github.com/gosuri/uiprogress.(*Progress).print(0xc000070780)
        /disk/ssd1/go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:127 +0x9e
github.com/gosuri/uiprogress.(*Progress).Listen(0xc000070780)
        /disk/ssd1/go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:114 +0x45
created by github.com/gosuri/uiprogress.(*Progress).Start
        /disk/ssd1/go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:134 +0x3f
```