### PR TITLE
fix: 修复get命令参数异常

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -260,6 +260,10 @@ func NewGetCommand() cli.Command {
 			InitAndCheck(LOGIN, CHECK, c)
 			upPath := c.Args().First()
 			localPath := "." + string(filepath.Separator)
+
+			if c.NArg() > 2 {
+				PrintErrorAndExit("upx get args limit 2")
+			}
 			if c.NArg() > 1 {
 				localPath = c.Args().Get(1)
 			}


### PR DESCRIPTION
修复当错误使用，添加过多参数时

例如

```bash
upx get a.jpg --work 12
```

a.jpg 文件将会被保存为 '--work' 文件的错误