### PR TITLE
让配置和数据文件路径符合 XDG 基本目录规范

### DIFF
--- a/config.go
+++ b/config.go
@@ -165,6 +165,11 @@ func getConfigName() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("USERPROFILE"), ".upx.cfg")
 	}
+
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, "upx", "config")
+	}
+
 	return filepath.Join(os.Getenv("HOME"), ".upx.cfg")
 }
 

--- a/config.go
+++ b/config.go
@@ -149,6 +149,11 @@ func saveConfigToFile() {
 	}
 	s := hashEncode(base64.StdEncoding.EncodeToString(b))
 
+	dir := filepath.Dir(confname)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		PrintErrorAndExit("create config directory: %v", err)
+	}
+
 	fd, err := os.Create(confname)
 	if err != nil {
 		PrintErrorAndExit("save config: %v", err)

--- a/db.go
+++ b/db.go
@@ -35,6 +35,11 @@ func getDBName() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("USERPROFILE"), ".upx.db")
 	}
+
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return filepath.Join(xdgDataHome, "upx", "upx.db")
+	}
+
 	return filepath.Join(os.Getenv("HOME"), ".upx.db")
 }
 

--- a/db.go
+++ b/db.go
@@ -187,7 +187,13 @@ func diffFileMetas(src []*fileMeta, dst []*fileMeta) []*fileMeta {
 }
 
 func initDB() (err error) {
-	db, err = leveldb.OpenFile(getDBName(), nil)
+	dbName := getDBName()
+	dir := filepath.Dir(dbName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		PrintErrorAndExit("create db directory: %v", err)
+	}
+
+	db, err = leveldb.OpenFile(dbName, nil)
 	if err != nil {
 		Print("db %v %s", err, getDBName())
 	}


### PR DESCRIPTION
upx 会把数据文件和配置文件都直接放在用户的 HOME 目录下

<img width="716" height="513" alt="image" src="https://github.com/user-attachments/assets/bda7f928-9ad9-4cdf-9cef-3efcb2ac12da" />

应该遵循 [XDG 基本目录规范](https://wiki.archlinuxcn.org/wiki/XDG_%E5%9F%BA%E6%9C%AC%E7%9B%AE%E5%BD%95)，将配置文件 `upx.cfg` 放在 `$XDG_CONFIG_HOME` 下，将 `upx.db` 放在 `$XDG_DATA_HOME` 下（我不清楚这里存的具体是什么数据，如果是缓存的话应该放在 `$XDG_CACHE_HOME`）。如果用户没有配置 XDG 基本目录，则回退到 `~/.upx.cfg` 和 `~/.upx.db`。

PR 已经做了实现，目前测试下来没有发现问题。

<img width="369" height="161" alt="image" src="https://github.com/user-attachments/assets/c31c5398-2502-4a8c-8a15-63a46a2d8138" />
<img width="674" height="194" alt="image" src="https://github.com/user-attachments/assets/2dbac7b3-11c1-4efe-bd4b-1cc17d92d6ff" />